### PR TITLE
Use default timezone when generating an ID for migration

### DIFF
--- a/migration.go
+++ b/migration.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	now = time.Now()
+	now = time.Now().UTC()
 
 	nameNormalizerRe = regexp.MustCompile(`([a-z])([A-Z])`)
 	versionFormat    = "20060102150405"


### PR DESCRIPTION
In case dev `A` generates a migration in EEST at 4pm and dev `B`
generates a migration in PST at 11am, the migration of dev `A` will
show up after the one of dev `B` although `A`'s migration was first.